### PR TITLE
Use URL pathname instead of route ID in span name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export function withOpenTelemetry(fn: Handle, opts?: TraceOptions): Handle {
     opts = opts || {};
     const tracer = trace.getTracer('@baselime/sveltekit-opentelemetry-middleware');
     return async function (args) {
-        const name = `${args.event.request.method} ${args.event.route.id}`;
+        const name = `${args.event.request.method} ${args.event.url.pathname}`;
         let requestId: string | undefined = undefined;
 
         if (opts.requestIdHeader) {


### PR DESCRIPTION
Using sveltekit's route ID is not enough in a lot of cases. e.g: when requesting to a route with a parameter, the sveltekit provided route ID only displays as /blog/[slug] whereas we really want to know what the actual slug value is. Same happens when you try to use rest parameters i.e /file/[...path]. Using `event.url.pathname` solves this problem by providing the full resolved pathname.